### PR TITLE
Issue #13276 - make stuck test handle invalid arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SRCDIR=extensions
 override CFLAGS+=-std=c99 -g -ggdb -Wall -I$(SRCDIR) 
 override LDFLAGS+=-lm
 
-test_objects=$(SRCDIR)/test.o $(SRCDIR)/spike.o $(SRCDIR)/utils.o $(SRCDIR)/gradient.o $(SRCDIR)/time_utils.o $(SRCDIR)/GeomagnetismLibrary.o $(SRCDIR)/wmm.o $(SRCDIR)/polycals.o
+test_objects=$(SRCDIR)/test.o $(SRCDIR)/stuck.o $(SRCDIR)/spike.o $(SRCDIR)/utils.o $(SRCDIR)/gradient.o $(SRCDIR)/time_utils.o $(SRCDIR)/GeomagnetismLibrary.o $(SRCDIR)/wmm.o $(SRCDIR)/polycals.o
 
 all: $(SRCDIR)/test
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Development Release 0.1.0 2018-05-17
+# Development Release 2.4.0 2018-05-18
 
 Issue #13276 - make stuck test handle invalid arguments
 - Use the absolute value of num parameter if it is negative

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# Development Release 0.1.0 2018-05-17
+
+Issue #13276 - make stuck test handle invalid arguments
+- Use the absolute value of num parameter if it is negative
+- Use the default value of 10 for num if it is 0
+
 # Version 0.0.2
 
 * Issue 12615 Merged updates from ooici/ion-functions repository

--- a/extensions/stuck.c
+++ b/extensions/stuck.c
@@ -14,6 +14,9 @@ int stuck(signed char *out, const double *dat, size_t len, double reso, int num)
 {
     int i,j,k;
     int i_max;
+    num=abs(num);
+    if(num==0)
+        num=10;
     int *tmp = malloc(sizeof(int) * (num-1));
     for(i=0;i<(len - num + 1);i++) {
         i_max = int_min(i+num, len)-1;


### PR DESCRIPTION
Changes to prevent the stuck function from throwing segfaults and to update the qc function tests. This change addresses the same issue as stream engine pull request at https://github.com/oceanobservatories/stream_engine/pull/54.