### PR TITLE
Corrected VEL3D-K DPA

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Development Release 2.4.1 2019-02-14
+
+Issue #13461 - corrected VEL3D-K data product algorithm.
+
 # Development Release 2.4.0 2018-05-18
 
 Issue #13276 - make stuck test handle invalid arguments

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,12 @@
-# Release 2.4.2 2019-02-14
+# Development Release 2.4.2 2019-02-14
 
 Issue #13461 - corrected VEL3D-K data product algorithm.
 
-# Release 2.4.1 2018-12-11
+# Development Release 2.4.1 2018-12-11
 
 PCO2W corrections
 
-# Release 2.4.0 2018-05-18
+# Development Release 2.4.0 2018-05-18
 
 Issue #13276 - make stuck test handle invalid arguments
 - Use the absolute value of num parameter if it is negative


### PR DESCRIPTION
The Matlab code supplied by Nortek in 2014 for the VEL3D-K DPA had 3 errors.

The VEL3D-K DPA has been corrected using code sent by Nortek in 2017. A new unit test has been coded  and new unit test values have been added to replace erroneous values in previously written unit tests.
