### PR TITLE
Issue #13402 - Fixed assorted bugs in FDCHP data product algorithms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Development Release 2.4.3 2019-06-03
+
+Issue #13402 - fixed assorted bugs in FDCHP data product algorithms
+
 # Release 2.4.2 2019-02-14
 
 Issue #13461 - corrected VEL3D-K data product algorithm.


### PR DESCRIPTION
Line 796: python expects integers for array indices, so fs=10.0 was causing an error because it made edge = fs * edge_sec a float (see lines 812, 815).
Line 1218: scipy nanmedian was deprecated and removed so it was necessary to change to numpy nanmedian. The scipy version was causing an import error.
Line 12222/12223: If the standard deviation was zero, the mask would be empty. This function is meant to remove spikes, not detect stuck values, and the empty mask was causing an error reshaping the data later in the DPA.
Lines 1497, 1531-1533: In the extreme corner case where the 20 minute sample ("dataset chunk") contains only 1 point of data, no time delta can be computed. The previous logic would compute the delta_time as NaN and then proceed to set the filldata timestamps to NaNs.