### PR TITLE
Issue #11399 Expose depth from pressure function

### DIFF
--- a/ion_functions/data/adcp_functions.py
+++ b/ion_functions/data/adcp_functions.py
@@ -1440,3 +1440,38 @@ def adcp_bin_depths_meters(dist_first_bin, bin_size, num_bins, sensor_depth, adc
     bin_depths_pd8 = sensor_depth + z_sign * (dist_first_bin + bin_size * bin_numbers)
 
     return bin_depths_pd8
+
+
+def depth_from_pressure_dbar(pressure, latitude, pressure_scale_factor=None):
+    """
+    Description:
+
+        Calculates depth from pressure. This function was extracted from
+        the adcp_bin_depths_dapa function.
+
+    Implemented by:
+
+        2019-06-29: Mark Steiner. Initial code.
+
+    Usage:
+
+        depth = depth_from_pressure_dbar(pressure, latitude, pressure_scale_factor)
+
+            where
+
+        depths =  [meters]
+
+        pressure = pressure [dbar]
+        latitude = latitude of the instrument [degrees]
+        pressure_scale_factor = scale factor to convert pressure to dbar [unitless]
+
+    """
+    # check for CI fill values.
+    pressure = replace_fill_with_nan(None, pressure)
+
+    # Apply scale factor to convert pressure to decibar
+    pressure_dbar = pressure * pressure_scale_factor if pressure_scale_factor else pressure;
+
+    # Calculate sensor depth using TEOS-10 toolbox z_from_p function
+    # note change of sign to make the sensor_depth variable positive
+    return -z_from_p(pressure_dbar, latitude)

--- a/ion_functions/data/generic_functions.py
+++ b/ion_functions/data/generic_functions.py
@@ -515,3 +515,38 @@ def bilinear_interpolation(x, y, points):
 
 def error(x, y):
     return np.abs(x - y) / np.abs(y)
+
+
+def select_non_zero_arg(a1, a2=None, a1_scale_factor=None, a2_scale_factor=None):
+    """
+    Description:
+
+        Test arrays a1 and a2 for non-zero values and return the non-zero array.
+        If needed, multiply the returned array by a scale factor so that it
+        will be in the expected units.
+
+    Implemented by:
+
+        2019-07-17: Mark Steiner. Initial code.
+
+    Usage:
+
+        out_value = select_non_zero_arg(a1, a2=None, a1_scale_factor=None, a2_scale_factor=None)
+
+            where
+
+        out_value = the scaled array containing at least one non-zero element.
+        a1 = an input array to be tested for non-zero elements.
+        a2 = an input array to be tested for non-zero elements.
+        a1_scale_factor = scale factor to apply to a1
+        a2_scale_factor = scale factor to apply to a2
+
+    References:
+
+        None.
+    """
+    if np.any(a1):
+        return a1 * a1_scale_factor if np.any(a1_scale_factor) else a1
+    if np.any(a2):
+        return a2 * a2_scale_factor if np.any(a2_scale_factor) else a2
+    return a1


### PR DESCRIPTION
The depth_from_pressure_dbar function is used to calculate the depth given the pressure (from a co-located CTD). The select_non_zero_arg function is called as a parameter function by stream engine to choose the non-zero depth form either the instrument's internal sensor, a co-located CTD or the nominal depth from asset management.